### PR TITLE
Add beepamac script and alpha README for experimental tools

### DIFF
--- a/alpha/README.md
+++ b/alpha/README.md
@@ -1,0 +1,23 @@
+# Scriptoolery - Alpha
+
+The **alpha** directory within **scriptoolery** houses experimental and prototype scripts that are currently under testing or in early development stages. These tools are functional but may still be evolving, making them suitable for adventurous users looking to try out new utilities or provide feedback.
+
+## Structure
+
+Each script in the **alpha** directory is organized into its own folder with the following structure:
+
+- **Script Folder**: Contains the main script file along with any dependencies.
+- **README.md**: Each script folder includes a README with detailed usage instructions, configuration options, and troubleshooting tips.
+- **LICENSE**: Licensing information, typically the BSD 2-Clause License, is included with each script.
+
+## Contents
+
+- **beepamac**: A Mac locator alert script designed to help find a Mac by playing a continuous alert sound, especially useful in remote setups. This script is configurable for remote compatibility and works on systems with `afplay` or `osascript` available. See `alpha/beepamac/README.md` for full details.
+
+## Note on Alpha Tools
+
+The tools in this directory are considered **experimental**. They may change frequently or have limited support. Users are encouraged to provide feedback and report any issues to help improve these utilities.
+
+## License
+
+The scripts within the **alpha** directory are licensed under the BSD 2-Clause License, unless otherwise noted. See individual folders for specific licensing details.

--- a/alpha/beepamac/LICENSE
+++ b/alpha/beepamac/LICENSE
@@ -1,0 +1,24 @@
+BSD 2-Clause License
+
+Copyright (c) 2024, Gale Fagan
+
+Redistribution and use in source and binary forms, with or without
+modification, are permitted provided that the following conditions are met:
+
+1. Redistributions of source code must retain the above copyright notice, this
+   list of conditions and the following disclaimer.
+
+2. Redistributions in binary form must reproduce the above copyright notice,
+   this list of conditions and the following disclaimer in the documentation
+   and/or other materials provided with the distribution.
+
+THIS SOFTWARE IS PROVIDED BY THE COPYRIGHT HOLDERS AND CONTRIBUTORS "AS IS"
+AND ANY EXPRESS OR IMPLIED WARRANTIES, INCLUDING, BUT NOT LIMITED TO, THE
+IMPLIED WARRANTIES OF MERCHANTABILITY AND FITNESS FOR A PARTICULAR PURPOSE ARE
+DISCLAIMED. IN NO EVENT SHALL THE COPYRIGHT HOLDER OR CONTRIBUTORS BE LIABLE
+FOR ANY DIRECT, INDIRECT, INCIDENTAL, SPECIAL, EXEMPLARY, OR CONSEQUENTIAL
+DAMAGES (INCLUDING, BUT NOT LIMITED TO, PROCUREMENT OF SUBSTITUTE GOODS OR
+SERVICES; LOSS OF USE, DATA, OR PROFITS; OR BUSINESS INTERRUPTION) HOWEVER
+CAUSED AND ON ANY THEORY OF LIABILITY, WHETHER IN CONTRACT, STRICT LIABILITY,
+OR TORT (INCLUDING NEGLIGENCE OR OTHERWISE) ARISING IN ANY WAY OUT OF THE USE
+OF THIS SOFTWARE, EVEN IF ADVISED OF THE POSSIBILITY OF SUCH DAMAGE.

--- a/alpha/beepamac/README.md
+++ b/alpha/beepamac/README.md
@@ -1,0 +1,72 @@
+# beepamac - Mac Locator Alert Script
+
+**beepamac** is a zsh script designed to help locate a Mac by playing an alert sound at maximum volume, especially useful in remote setups. The script has been developed with headless compatibility in mind but is primarily intended for **remote use**, where users may have partial system access but lack physical proximity to the Mac.
+
+## Features
+
+- Sets Mac’s output volume to maximum to ensure an effective alert
+- Plays a continuous alert sound until manually stopped or a condition is met
+- Uses a semaphore file for quick start-stop control
+- Works in remote setups; compatible with headless use, though untested in strictly headless environments
+
+## Requirements
+
+- **zsh** shell (default on macOS)
+- **macOS** system sound (`afplay` recommended for alert playback)
+- Limited dependency on `osascript` for sound playback (optional) and volume control
+
+## Installation
+
+1. Clone **beepamac** to a directory of your choice:
+
+   ```bash
+   git clone https://github.com/galeep/scriptoolery.git
+   cd scriptoolery/alpha/beepamac
+   ```
+
+2. Ensure the script has execution permissions:
+
+   ```bash
+   chmod +x beepamac.sh
+   ```
+
+## Usage
+
+Run the script to start the alert:
+
+```bash
+./beepamac.sh
+```
+
+### Controls
+
+- **Starting**: Executing `beepamac.sh` will set the volume to maximum and begin playing the alert sound in a loop.
+- **Stopping**: To stop the alert, delete the semaphore file located in `/tmp`:
+
+  ```bash
+  rm /tmp/mac_beep_locator_stop.pid
+  ```
+
+### Configuration Options
+
+Edit the script to adjust configuration variables as needed:
+
+- **BEEP_METHOD**: Choose between `afplay` (recommended) or `osascript` for sound playback. For remote setups, `afplay` is generally more reliable.
+- **ALERT_SOUND**: Modify the alert sound file location, if desired.
+- **VERBOSE**: Set to `true` for detailed console logging.
+
+## Remote Operation Notes
+
+The **beepamac** script is designed to function in remote setups where you may not have GUI access but need to locate the Mac audibly. The script is compatible with headless setups as well but has undergone limited testing in strictly headless environments. 
+
+- **Recommended for Remote Use**: Use `afplay` as the `BEEP_METHOD` for better compatibility.
+- **Volume Reset**: Volume restoration on exit may vary depending on the connection type and system permissions. Manually adjust the volume if necessary in remote-only sessions.
+
+## Troubleshooting
+
+- **Script fails in headless mode**: If working in a headless-only setup, `afplay` is recommended as `osascript` may not function fully.
+- **Volume Reset Issues**: If the volume is not restored upon exit, confirm permissions for `osascript`, or reset manually.
+
+## License
+
+Licensed under the BSD 2-Clause License. See LICENSE for details.

--- a/alpha/beepamac/beepamac.sh
+++ b/alpha/beepamac/beepamac.sh
@@ -1,0 +1,165 @@
+#!/bin/zsh
+
+# beepamac - Mac Locator Alert Script
+# Copyright (c) 2024 Gale Fagan - gep.dev - gep at fagan dot io
+# Licensed under the BSD 2-Clause License. See the LICENSE file in the root directory for details.
+#
+# This script sets the output volume to maximum and repeatedly plays an alert
+# sound until a specified condition is met. Useful for locating a Mac,
+# especially in remote scenarios.
+
+
+# Set constants for log file, semaphore file, and alert sound path
+LOG_FILE="/tmp/mac_beep_locator.log"
+SEMAPHORE_FILE="/tmp/mac_beep_locator_stop.pid"
+ALERT_SOUND="/System/Library/Sounds/Ping.aiff" # Path to alert sound (modify if needed)
+
+# Debug and verbosity flags for controlled output
+DEBUG=true
+VERBOSE=true
+
+# Default beep method (afplay recommended for headless environments)
+BEEP_METHOD="${BEEP_METHOD:-afplay}"
+
+# Current volume level placeholder, initialized later
+CURRENT_VOLUME=50
+
+# Ensure consistent and readable logging with level, timestamp, and guaranteed newline
+function log() {
+    local level="$1"
+    shift
+    local message="$*"
+    [[ -z "$message" ]] && message="No message provided"
+
+    # Format log entry and append newline
+    local log_entry
+    log_entry="$(printf '[%s] [%s] %s\n' "$(date)" "$level" "$message")"
+
+    # Log to file and optionally to console if verbose
+    printf "%s\n" "$log_entry" >> "$LOG_FILE"
+    [[ "$VERBOSE" == true ]] && printf "%s\n" "$log_entry" >&2
+}
+
+# Function to retrieve current volume (warns if not retrievable in headless environments)
+CURRENT_VOLUME=$(osascript -e "output volume of (get volume settings)" 2>/dev/null)
+if [[ -z "$CURRENT_VOLUME" ]]; then
+    log "WARN" "Failed to retrieve current volume using osascript. Defaulting to $CURRENT_VOLUME."
+fi
+
+# Function to set volume to maximum, retrying if needed
+function set_max_volume() {
+    log "INFO" "Setting volume to maximum."
+    local retries=3
+    for (( i=0; i < retries; i++ )); do
+        if osascript -e "set volume output volume 100" 2>> "$LOG_FILE"; then
+            log "INFO" "Volume set to maximum."
+            return
+        else
+            log "WARN" "Failed to set volume (attempt $((i+1))). Retrying..."
+            sleep 0.5
+        fi
+    done
+    log "ERROR" "Failed to set volume to maximum after $retries attempts."
+}
+
+# Function to restore original volume level
+function restore_volume() {
+    log "INFO" "Restoring volume to original level ($CURRENT_VOLUME)."
+    local retries=3
+    for (( i=0; i < retries; i++ )); do
+        if osascript -e "set volume output volume $CURRENT_VOLUME" 2>> "$LOG_FILE"; then
+            log "INFO" "Volume restored."
+            return
+        else
+            log "WARN" "Failed to restore volume (attempt $((i+1))). Retrying..."
+            sleep 0.5
+        fi
+    done
+    log "ERROR" "Failed to restore volume after $retries attempts."
+}
+
+# Function to play alert sound using afplay
+function make_beep() {
+    log "INFO" "Playing alert sound with $BEEP_METHOD."
+    if [[ ! -f "$ALERT_SOUND" ]]; then
+        log "ERROR" "Alert sound file '$ALERT_SOUND' not found. Exiting."
+        exit 1
+    fi
+    afplay "$ALERT_SOUND" 2>> "$LOG_FILE"
+    if [[ $? -ne 0 && "$CLEANED_UP" == false ]]; then
+        log "ERROR" "Failed to play alert sound."
+        exit 1
+    fi
+}
+
+# Function to play alert sound with osascript as fallback method
+function make_beep_osascript() {
+    log "INFO" "Attempting to play alert sound with osascript."
+    osascript -e 'beep' 2>> "$LOG_FILE"
+    if [[ $? -ne 0 && "$CLEANED_UP" == false ]]; then
+        log "ERROR" "Failed to play alert sound with osascript."
+        exit 1
+    fi
+}
+
+# Cleanup function for orderly shutdown
+CLEANED_UP=false
+function cleanup() {
+    if [[ "$CLEANED_UP" == true ]]; then return; fi
+    CLEANED_UP=true
+    log "INFO" "Performing cleanup."
+
+    # Terminate any child processes and clean up semaphore file
+    pkill -P $$ || jobs -p | xargs kill 2>/dev/null
+    [[ -f "$SEMAPHORE_FILE" ]] && rm -f "$SEMAPHORE_FILE"
+
+    # Restore original volume and reset terminal state
+    restore_volume
+    log "INFO" "Script exited successfully."
+    stty sane
+    echo "Script terminated." >&2
+    exit 0
+}
+
+# Trap signals for proper cleanup
+trap 'cleanup' INT TERM HUP QUIT
+trap '[[ "$CLEANED_UP" == false ]] && cleanup' EXIT
+
+# Check for an existing instance (semaphore file handling)
+if [[ -f "$SEMAPHORE_FILE" ]]; then
+    other_pid=$(cat "$SEMAPHORE_FILE")
+    if ps -p "$other_pid" > /dev/null 2>&1; then
+        log "WARN" "Another instance (PID $other_pid) is running. Exiting."
+        exit 1
+    else
+        log "WARN" "Stale semaphore file detected. Removing it."
+        rm -f "$SEMAPHORE_FILE"
+    fi
+fi
+log "INFO" "Starting script with PID $$"
+echo $$ > "$SEMAPHORE_FILE"
+
+# Set volume to max and begin alert loop
+set_max_volume
+
+# Main loop (runs until semaphore file is deleted)
+while true; do
+    if [[ ! -f "$SEMAPHORE_FILE" ]]; then
+        log "INFO" "Semaphore file removed. Stopping script."
+        exit 0
+    fi
+
+    # Play alert sound with selected method
+    if [[ "$BEEP_METHOD" == "afplay" ]]; then
+        make_beep
+    elif [[ "$BEEP_METHOD" == "osascript" ]]; then
+        make_beep_osascript
+    else
+        log "ERROR" "Invalid BEEP_METHOD: '$BEEP_METHOD'. Exiting."
+        exit 1
+    fi
+
+    # Brief pause for responsiveness
+    sleep 0.5
+done
+


### PR DESCRIPTION
This PR introduces the following updates:

1. **beepamac** - a Mac locator alert script
   - Adds **beepamac**, a zsh script designed to emit a repeated alert sound at maximum volume to help locate a Mac, especially useful in remote or headless scenarios.
   - Configurable options include:
     - **BEEP_METHOD**: Default set to `afplay`, with fallback to `osascript`.
     - **ALERT_SOUND**: Path to the sound file used for alerts.
     - **VERBOSE**: Toggles detailed logging.
   - Comprehensive README included in `alpha/beepamac` with setup, usage, configuration, and troubleshooting information.

2. **alpha Directory README**:
   - Adds a README to the **alpha** directory, outlining the purpose of experimental scripts and the structure for each tool.
   - Provides an overview of **beepamac** and sets expectations for the experimental nature of tools in this directory.

